### PR TITLE
small fix, otherwise importing the npm module will have error 

### DIFF
--- a/libs/pay.js
+++ b/libs/pay.js
@@ -2,7 +2,7 @@
 
 var BigNumber = require("bignumber.js");
 
-var Utils = require("./utils");
+var Utils = require("./Utils");
 var QRCode = require("./qrcode");
 var Config = require("./config");
 


### PR DESCRIPTION
the error is pay.js require "u(lowercase)til" should be upper case U here.