### PR TITLE
update gulpfile.js to output nebPay.min.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -83,6 +83,9 @@ gulp.task('nebpay', ['clean'], function () {
         .pipe(source('nebPay.js'))
         .pipe(buffer())
         .pipe(rename(dst + '.js'))
+        .pipe(gulp.dest(DEST))
+        .pipe(uglify())
+        .pipe(rename(dst + '.min.js'))
         .pipe(gulp.dest(DEST));
 });
 


### PR DESCRIPTION
Update gulpfile.js to output nebPay.min.js in ./dist folder.
Now if one run the command "gulp", he would get "nebPay.js" and "nebPay.min.js" in ./dist folder.
The file size of "nebPay.js" is 205.0 KB and "nebPay.min.js" is 54.5 KB.