### PR TITLE
In English version  introducion, call funtion's return is missing

### DIFF
--- a/doc/NebPay_Introduction.md
+++ b/doc/NebPay_Introduction.md
@@ -170,6 +170,10 @@ deploy(source, sourceType, args, options)
 
 `options` Refer to `options` parameter description
 
+###### return
+
+- `serialNumber` transaction's serival number, used for query transaction info.
+
 ***
 
 ##### queryPayInfo


### PR DESCRIPTION
In English version  introducion, call funtion's return is missing